### PR TITLE
Provide padding for each side of the container

### DIFF
--- a/src/flexGrid/flex.style.js
+++ b/src/flexGrid/flex.style.js
@@ -13,8 +13,8 @@ export default styled("div")`
     &.flex-grid-container {
       margin-left: -${props => (props.theme.dimensions || {}).columnPadding || 3}px;
       margin-right: -${props => (props.theme.dimensions || {}).columnPadding || 3}px;
-      width: calc(100% + ${props => (props.theme.dimensions || {}).columnPadding || 3}px);
-      max-width: calc(100% + ${props => (props.theme.dimensions || {}).columnPadding || 3}px);
+      width: calc(100% + ${props => ((props.theme.dimensions || {}).columnPadding || 3) * 2}px);
+      max-width: calc(100% + ${props => ((props.theme.dimensions || {}).columnPadding || 3) * 2}px);
 
       > .flex-item {
         padding-left: ${props => (props.theme.dimensions || {}).columnPadding || 3}px;


### PR DESCRIPTION
This is to fix a left/right padding issue.
Basically setting container on FlexGrid adds a little too much padding to the right side of row.

before:
![image](https://user-images.githubusercontent.com/1529103/46426117-d441b600-c6fa-11e8-9201-dafcaa2a8d39.png)

after:
![image](https://user-images.githubusercontent.com/1529103/46426075-b2483380-c6fa-11e8-94b5-df39eec38e2c.png)
