### PR TITLE
fix reference to externalized PropTypes package

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const { join } = require("path");
 const externals = {
   react: "React",
   "@emotion/react": "emotionReact",
-  "prop-types": "propTypes",
+  "prop-types": "PropTypes",
 };
 
 const umdBuild = {


### PR DESCRIPTION
Thank you for contributing to FlexItem. Before asking for reviews on this pull request, please confirm that the following is done.

- [x] Lint tests have passed.
- [x] Add a log to the CHANGELOG.md file for what you are changing.

Externalized reference to prop-types package was to "propTypes", should be "PropTypes".
